### PR TITLE
Use process.env after fixing it

### DIFF
--- a/src/lib/actions/runCommand.js
+++ b/src/lib/actions/runCommand.js
@@ -3,7 +3,6 @@ import { spawn } from 'child_process';
 window.running = {};
 
 const vagrantEnv = {
-	...process.env,
 	CLICOLOR_FORCE: 'yes',
 	GIT_COLOR: 'yes',
 
@@ -19,7 +18,10 @@ export default function runCommand(path, command, args = [], opts = {}) {
 
 		let spawnOpts = Object.assign({}, {
 			cwd: path,
-			env: vagrantEnv,
+			env: {
+				...process.env,
+				...vagrantEnv,
+			},
 		}, opts);
 
 		const proc = spawn( command, args, spawnOpts );


### PR DESCRIPTION
Previously, we were using process.env from when the module loaded. This caused it to miss out on the fixPath corrections. See #18 for previous fix, and discussion.
